### PR TITLE
Text handling improvements

### DIFF
--- a/src/backend/config.rs
+++ b/src/backend/config.rs
@@ -41,9 +41,9 @@ impl Config {
                 // happens mid-write
                 let mut config_file = String::from("config.json");
                 if testing {
-                    config_file = format!("test.{}", config_file);
+                    config_file = format!("test.{config_file}");
                 }
-                let tmp_file = format!("{}.tmp", config_file);
+                let tmp_file = format!("{config_file}.tmp");
 
                 let config_file_path = conf_local_dir.join(&config_file);
                 let tmp_file_path = conf_local_dir.join(&tmp_file);
@@ -59,10 +59,10 @@ impl Config {
 
                 // Rename .tmp file to old file
                 rename(&tmp_file_path, &config_file_path)
-                    .with_context(|| { format!("Failed to update config file with rename:\ntmp_file: {:?}\nconfig_file:{:?}", tmp_file, config_file)})?;
+                    .with_context(|| { format!("Failed to update config file with rename:\ntmp_file: {tmp_file:?}\nconfig_file:{config_file:?}")})?;
             }
             Err(e) => {
-                println!("Failed getting the configuration location: {:?}", e);
+                println!("Failed getting the configuration location: {e:?}");
                 panic!()
             }
         }
@@ -80,9 +80,8 @@ pub fn get_config_dir() -> Result<PathBuf> {
     // Create our checklist folder in local directory if it doesn't exist
     if !conf_local_dir.exists() {
         // Create a brand new config file
-        std::fs::create_dir_all(&conf_local_dir).with_context(|| {
-            format!("Failed to create the following path: {:?}", conf_local_dir)
-        })?;
+        std::fs::create_dir_all(&conf_local_dir)
+            .with_context(|| format!("Failed to create the following path: {conf_local_dir:?}"))?;
     }
 
     Ok(conf_local_dir)
@@ -95,12 +94,12 @@ pub fn read_config(testing: bool) -> Result<Config> {
         Ok(local_config_dir) => {
             let mut config_f = String::from("config.json");
             if testing {
-                config_f = format!("test.{}", config_f);
+                config_f = format!("test.{config_f}");
             }
             let config_file_path = local_config_dir.join(&config_f);
 
             let config_file = std::fs::File::open(&config_file_path)
-                .with_context(|| format!("Failed to open {:?}", config_file_path))?;
+                .with_context(|| format!("Failed to open {config_file_path:?}"))?;
             let reader = BufReader::new(config_file);
 
             let config: Config = serde_json::from_reader(reader)?;
@@ -108,7 +107,7 @@ pub fn read_config(testing: bool) -> Result<Config> {
             Ok(config)
         }
         Err(e) => {
-            println!("Failed getting the configuration location: {:?}", e);
+            println!("Failed getting the configuration location: {e:?}");
             panic!()
         }
     }
@@ -132,12 +131,12 @@ pub fn set_new_path(path: PathBuf, testing: bool) -> Result<()> {
         Ok(mut config) => {
             config.db_path = absolute_path.clone();
             config.save(testing)?;
-            println!("Updated db path to {:?}", absolute_path);
+            println!("Updated db path to {absolute_path:?}");
         }
         Err(_) => {
             let config = Config::new(absolute_path.clone());
             config.save(testing)?;
-            println!("Set db path to {:?}", absolute_path);
+            println!("Set db path to {absolute_path:?}");
         }
     }
     Ok(())
@@ -155,7 +154,7 @@ mod tests {
                 let config_file = base_directories
                     .config_local_dir()
                     .join("checklist/test.config.json");
-                assert_eq!(config_file.exists(), true);
+                assert!(config_file.exists());
             }
             Err(_) => {
                 println!("Encounted an error saving the test config file");

--- a/src/backend/database.rs
+++ b/src/backend/database.rs
@@ -34,7 +34,7 @@ pub fn make_memory_connection() -> Result<Connection> {
 /// Returns a `Result<Connection>` given a `&Pathbuf` to a SQLite database
 pub fn make_connection(path: &PathBuf) -> Result<Connection> {
     let conn = Connection::open(path)
-        .with_context(|| format!("Failed connect to the database at {:?}", path))?;
+        .with_context(|| format!("Failed connect to the database at {path:?}"))?;
 
     Ok(conn)
 }
@@ -56,7 +56,7 @@ pub fn create_sqlite_db(testing: bool) -> Result<()> {
         sqlite_path = sqlite_path.join("checklist.sqlite");
     }
 
-    println!("Setting up a database at {:?}", sqlite_path);
+    println!("Setting up a database at {sqlite_path:?}");
     let conn = make_connection(&sqlite_path)?;
 
     let config = Config::new(sqlite_path);
@@ -265,7 +265,7 @@ mod tests {
         // Check if data we get back from database matches
         let task_list = get_all_db_contents(&conn).unwrap();
         assert_eq!(task_list.len(), 1);
-        let task = task_list.tasks.get(0).unwrap();
+        let task = task_list.tasks.first().unwrap();
         assert_eq!(task.name, "My new task".to_string());
         assert_eq!(task.description, None);
         assert_eq!(task.latest, None);
@@ -280,7 +280,7 @@ mod tests {
         // Again, see if data we get back matches
         let task_list = get_all_db_contents(&conn).unwrap();
         assert_eq!(task_list.len(), 1);
-        let task = task_list.tasks.get(0).unwrap();
+        let task = task_list.tasks.first().unwrap();
         assert_eq!(task.name, "My new task".to_string());
         assert_eq!(task.description, Some("New description".to_string()));
         assert_eq!(task.latest, Some("New latest".to_string()));

--- a/src/display/add.rs
+++ b/src/display/add.rs
@@ -283,12 +283,10 @@ impl App {
         match key.modifiers {
             KeyModifiers::CONTROL => match key.code {
                 KeyCode::Left => {
-                    if self.entry_mode == EntryMode::Add {
-                        self.add_stage.back();
-                    }
-                    if self.entry_mode == EntryMode::Update {
-                        self.update_stage = Stage::Staging;
-                    }
+                    self.text_info.character_index = 0;
+                }
+                KeyCode::Right => {
+                    self.text_info.character_index = self.get_text_length();
                 }
                 KeyCode::Char('a') => {
                     self.highlight_all();

--- a/src/display/add.rs
+++ b/src/display/add.rs
@@ -232,6 +232,7 @@ impl App {
             self.move_cursor_left();
         } else {
             self.text_info.character_index = left;
+            self.text_info.is_text_highlighted = false;
         }
     }
 

--- a/src/display/add.rs
+++ b/src/display/add.rs
@@ -188,52 +188,50 @@ impl App {
     }
 
     fn delete_char(&mut self) {
-        let is_not_cursor_leftmost = self.text_info.character_index != 0;
-        if is_not_cursor_leftmost {
-            let right;
-            let left;
+        let right;
+        let left;
 
-            if self.text_info.is_text_highlighted {
-                (left, right) = self.get_highlight_start_and_end();
-            } else {
-                right = self.text_info.character_index;
-                left = right - 1;
+        if self.text_info.is_text_highlighted {
+            (left, right) = self.get_highlight_start_and_end();
+        } else if self.text_info.character_index == 0 {
+            return;
+        } else {
+            right = self.text_info.character_index;
+            left = right - 1;
+        }
+
+        let stage = self.get_stage_off_entry_mode();
+
+        match stage {
+            Stage::Name => {
+                let before_char_to_delete = self.inputs.name.chars().take(left);
+                let after_char_to_delete = self.inputs.name.chars().skip(right);
+                self.inputs.name = before_char_to_delete.chain(after_char_to_delete).collect();
             }
-
-            let stage = self.get_stage_off_entry_mode();
-
-            match stage {
-                Stage::Name => {
-                    let before_char_to_delete = self.inputs.name.chars().take(left);
-                    let after_char_to_delete = self.inputs.name.chars().skip(right);
-                    self.inputs.name = before_char_to_delete.chain(after_char_to_delete).collect();
-                }
-                Stage::Description => {
-                    let before_char_to_delete = self.inputs.description.chars().take(left);
-                    let after_char_to_delete = self.inputs.description.chars().skip(right);
-                    self.inputs.description =
-                        before_char_to_delete.chain(after_char_to_delete).collect();
-                }
-                Stage::Latest => {
-                    let before_char_to_delete = self.inputs.latest.chars().take(left);
-                    let after_char_to_delete = self.inputs.latest.chars().skip(right);
-                    self.inputs.latest =
-                        before_char_to_delete.chain(after_char_to_delete).collect();
-                }
-                Stage::Tags => {
-                    let before_char_to_delete = self.inputs.tags_input.chars().take(left);
-                    let after_char_to_delete = self.inputs.tags_input.chars().skip(right);
-                    self.inputs.tags_input =
-                        before_char_to_delete.chain(after_char_to_delete).collect();
-                }
-                _ => {}
+            Stage::Description => {
+                let before_char_to_delete = self.inputs.description.chars().take(left);
+                let after_char_to_delete = self.inputs.description.chars().skip(right);
+                self.inputs.description =
+                    before_char_to_delete.chain(after_char_to_delete).collect();
             }
-
-            if !self.text_info.is_text_highlighted {
-                self.move_cursor_left();
-            } else {
-                self.text_info.character_index = left;
+            Stage::Latest => {
+                let before_char_to_delete = self.inputs.latest.chars().take(left);
+                let after_char_to_delete = self.inputs.latest.chars().skip(right);
+                self.inputs.latest = before_char_to_delete.chain(after_char_to_delete).collect();
             }
+            Stage::Tags => {
+                let before_char_to_delete = self.inputs.tags_input.chars().take(left);
+                let after_char_to_delete = self.inputs.tags_input.chars().skip(right);
+                self.inputs.tags_input =
+                    before_char_to_delete.chain(after_char_to_delete).collect();
+            }
+            _ => {}
+        }
+
+        if !self.text_info.is_text_highlighted {
+            self.move_cursor_left();
+        } else {
+            self.text_info.character_index = left;
         }
     }
 

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -2,6 +2,7 @@
 pub mod add;
 pub mod quick_actions;
 pub mod render;
+pub mod text;
 pub mod theme;
 pub mod tui;
 pub mod ui;

--- a/src/display/quick_actions.rs
+++ b/src/display/quick_actions.rs
@@ -13,7 +13,7 @@ impl App {
         self.add_stage = Stage::Name;
         self.entry_mode = EntryMode::QuickAdd;
         self.add_popup = !self.add_popup;
-        self.character_index = 0;
+        self.text_info.character_index = 0;
         self.inputs = Inputs::default();
     }
 

--- a/src/display/render.rs
+++ b/src/display/render.rs
@@ -375,6 +375,11 @@ fn text_cursor_logic(
     x_offset: u16,
     y_offset: u16,
 ) {
+    // If in a highlight, just early return to hide the cursor
+    if app.text_info.is_text_highlighted {
+        return;
+    }
+
     // Idea: create a BtreeMap where
     // keys - the line row
     // values - the line contents as a vector of strings (words)
@@ -1258,7 +1263,7 @@ pub fn render_tags_popup(f: &mut Frame, app: &mut App, area: Rect) {
 
     for (i, tag) in task_tags_vec.iter().enumerate() {
         let mut span_object = Span::styled(
-            format!(" {tag} "),
+            format!(" {tag} ",),
             Style::default().fg(app.theme.text_colors.tags),
         );
         if i == app.tags_highlight_value && app.highlight_tags {

--- a/src/display/render.rs
+++ b/src/display/render.rs
@@ -15,6 +15,7 @@ use ratatui::{
 
 use crate::backend::task::Display;
 use crate::backend::task::{Status, Task, Urgency};
+use crate::display::text::highlight_text;
 use crate::display::theme::Theme;
 use crate::display::tui::{App, LayoutView};
 
@@ -140,7 +141,7 @@ impl Task {
 
                 for tag in task_tags_vec {
                     tags_span_vec.push(Span::styled(
-                        format!(" {} ", tag),
+                        format!(" {tag} "),
                         Style::default().fg(theme.text_colors.tags),
                     ));
                     tags_span_vec.push(Span::from("|"));
@@ -390,10 +391,10 @@ fn text_cursor_logic(
     let (strings_on_lines, _) = map_string_to_lines(current_string, text_width);
 
     // Cursor logic - adjustment
-    let mut x = app.character_index;
+    let mut x = app.text_info.character_index;
     let mut row = 0;
 
-    if app.character_index > 0 {
+    if app.text_info.character_index > 0 {
         for (k, v) in strings_on_lines.iter() {
             let line_length: usize = v
                 .iter()
@@ -987,10 +988,16 @@ pub fn render_name_popup(f: &mut Frame, app: &mut App, area: Rect) {
 
     //let instructions = "What do you want to name your task?";
 
+    let text_input = if app.text_info.is_text_highlighted {
+        highlight_text(app.inputs.name.clone(), app)
+    } else {
+        Line::from(app.inputs.name.as_str())
+    };
+
     let line_vec = vec![
         //Line::from(instructions),
         //Line::from(""),
-        Line::from(app.inputs.name.as_str()),
+        text_input,
     ];
     let line_vec_len = line_vec.len();
     let blurb = Paragraph::new(Text::from(line_vec));
@@ -1119,11 +1126,13 @@ pub fn render_description_popup(f: &mut Frame, app: &mut App, area: Rect) {
 
     let instructions = "Feel free to add a description";
 
-    let line_vec = vec![
-        Line::from(instructions),
-        Line::from(""),
-        Line::from(app.inputs.description.as_str()),
-    ];
+    let text_input = if app.text_info.is_text_highlighted {
+        highlight_text(app.inputs.description.clone(), app)
+    } else {
+        Line::from(app.inputs.description.as_str())
+    };
+
+    let line_vec = vec![Line::from(instructions), Line::from(""), text_input];
     let line_vec_len = line_vec.len();
 
     let blurb = Paragraph::new(Text::from(line_vec));
@@ -1162,11 +1171,14 @@ pub fn render_latest_popup(f: &mut Frame, app: &mut App, area: Rect) {
 
     let instructions = "Any updates?";
     let instructions_len = instructions.chars().count();
-    let line_vec = vec![
-        Line::from(instructions),
-        Line::from(""),
-        Line::from(app.inputs.latest.as_str()),
-    ];
+
+    let text_input = if app.text_info.is_text_highlighted {
+        highlight_text(app.inputs.latest.clone(), app)
+    } else {
+        Line::from(app.inputs.latest.as_str())
+    };
+
+    let line_vec = vec![Line::from(instructions), Line::from(""), text_input];
     let line_vec_len = line_vec.len();
 
     let blurb = Paragraph::new(Text::from(line_vec));
@@ -1224,7 +1236,14 @@ pub fn render_tags_popup(f: &mut Frame, app: &mut App, area: Rect) {
     }
 
     line_vec.push(Line::from(""));
-    line_vec.push(Line::from(app.inputs.tags_input.as_str()));
+
+    let text_input = if app.text_info.is_text_highlighted {
+        highlight_text(app.inputs.tags_input.clone(), app)
+    } else {
+        Line::from(app.inputs.tags_input.as_str())
+    };
+
+    line_vec.push(text_input);
     let line_vec_len = line_vec.len();
 
     let blurb = Paragraph::new(Text::from(line_vec));
@@ -1239,7 +1258,7 @@ pub fn render_tags_popup(f: &mut Frame, app: &mut App, area: Rect) {
 
     for (i, tag) in task_tags_vec.iter().enumerate() {
         let mut span_object = Span::styled(
-            format!(" {} ", tag),
+            format!(" {tag} "),
             Style::default().fg(app.theme.text_colors.tags),
         );
         if i == app.tags_highlight_value && app.highlight_tags {

--- a/src/display/text.rs
+++ b/src/display/text.rs
@@ -62,6 +62,7 @@ impl App {
         self.text_info.is_text_highlighted = true;
         self.text_info.highlight_info.start = 0;
         self.text_info.highlight_info.distance = self.get_text_length() as i32;
+        self.text_info.character_index = 0;
     }
 
     pub fn get_text_length(&mut self) -> usize {

--- a/src/display/text.rs
+++ b/src/display/text.rs
@@ -1,0 +1,83 @@
+use crate::display::tui::App;
+use ratatui::{
+    style::{Color, Style},
+    text::{Line, Span},
+};
+
+pub struct TextInfo {
+    pub character_index: usize,
+    pub is_text_highlighted: bool,
+    pub highlight_info: HighLightInfo,
+}
+
+pub struct HighLightInfo {
+    pub start: usize,
+    pub distance: i32,
+}
+
+pub enum HighlightDirection {
+    Left,
+    Right,
+}
+
+impl TextInfo {
+    pub fn new() -> Self {
+        Self {
+            character_index: 0,
+            is_text_highlighted: false,
+            highlight_info: HighLightInfo {
+                start: 0,
+                distance: 0,
+            },
+        }
+    }
+}
+
+impl App {
+    pub fn highlight_single_char(&mut self, direction: HighlightDirection) {
+        if !self.text_info.is_text_highlighted {
+            self.text_info.is_text_highlighted = true;
+            self.text_info.highlight_info.start = self.text_info.character_index;
+            self.text_info.highlight_info.distance = 0;
+        }
+        match direction {
+            HighlightDirection::Left => {
+                let cursor_moved_left = self.text_info.character_index.saturating_sub(1);
+                self.text_info.character_index = self.clamp_cursor(cursor_moved_left);
+                self.text_info.highlight_info.distance = self.text_info.character_index as i32
+                    - self.text_info.highlight_info.start as i32;
+            }
+            HighlightDirection::Right => {
+                let cursor_moved_right = self.text_info.character_index.saturating_add(1);
+                self.text_info.character_index = self.clamp_cursor(cursor_moved_right);
+                self.text_info.highlight_info.distance = self.text_info.character_index as i32
+                    - self.text_info.highlight_info.start as i32;
+            }
+        }
+    }
+}
+
+pub fn highlight_text(text: String, app: &App) -> Line {
+    let start;
+    let end;
+    let tmp = app.text_info.highlight_info.start as i32 + app.text_info.highlight_info.distance;
+    if tmp as usize > app.text_info.highlight_info.start {
+        start = app.text_info.highlight_info.start;
+        end = tmp as usize;
+    } else {
+        end = app.text_info.highlight_info.start;
+        start = tmp as usize;
+    }
+
+    let pre_highlight = &text[0..start];
+    let pre_highlight_span = Span::raw(pre_highlight.to_owned());
+    let highlight = &text[start..end];
+    let highlight_span = Span::styled(highlight.to_owned(), Style::default().bg(Color::Yellow));
+    let post_highlight = &text[end..];
+    let post_highlight_span = Span::raw(post_highlight.to_owned());
+    Line::from(vec![
+        pre_highlight_span,
+        highlight_span,
+        post_highlight_span,
+    ])
+}

--- a/src/display/text.rs
+++ b/src/display/text.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    style::{Color, Style},
+    style::Style,
     text::{Line, Span},
 };
 
@@ -81,7 +81,7 @@ impl App {
         let end;
         let tmp =
             self.text_info.highlight_info.start as i32 + self.text_info.highlight_info.distance;
-        if tmp as usize > self.text_info.highlight_info.start {
+        if tmp as usize >= self.text_info.highlight_info.start {
             start = self.text_info.highlight_info.start;
             end = tmp as usize;
         } else {
@@ -99,9 +99,15 @@ pub fn highlight_text(text: String, app: &App) -> Line {
     let pre_highlight = &text[0..start];
     let pre_highlight_span = Span::raw(pre_highlight.to_owned());
     let highlight = &text[start..end];
-    let highlight_span = Span::styled(highlight.to_owned(), Style::default().bg(Color::Yellow));
+    let highlight_span = Span::styled(
+        highlight.to_owned(),
+        Style::default()
+            .bg(app.theme.theme_colors.highlight_color_bg)
+            .fg(app.theme.theme_colors.highlight_color_fg),
+    );
     let post_highlight = &text[end..];
     let post_highlight_span = Span::raw(post_highlight.to_owned());
+
     Line::from(vec![
         pre_highlight_span,
         highlight_span,

--- a/src/display/text.rs
+++ b/src/display/text.rs
@@ -1,8 +1,10 @@
-use crate::display::tui::App;
 use ratatui::{
     style::{Color, Style},
     text::{Line, Span},
 };
+
+use crate::display::add::Stage;
+use crate::display::tui::App;
 
 pub struct TextInfo {
     pub character_index: usize,
@@ -55,19 +57,44 @@ impl App {
             }
         }
     }
+
+    pub fn highlight_all(&mut self) {
+        self.text_info.is_text_highlighted = true;
+        self.text_info.highlight_info.start = 0;
+        self.text_info.highlight_info.distance = self.get_text_length() as i32;
+    }
+
+    pub fn get_text_length(&mut self) -> usize {
+        let stage = self.get_stage_off_entry_mode();
+
+        match stage {
+            Stage::Name => self.inputs.name.len(),
+            Stage::Description => self.inputs.description.len(),
+            Stage::Latest => self.inputs.latest.len(),
+            Stage::Tags => self.inputs.tags_input.len(),
+            _ => 0,
+        }
+    }
+
+    pub fn get_highlight_start_and_end(&self) -> (usize, usize) {
+        let start;
+        let end;
+        let tmp =
+            self.text_info.highlight_info.start as i32 + self.text_info.highlight_info.distance;
+        if tmp as usize > self.text_info.highlight_info.start {
+            start = self.text_info.highlight_info.start;
+            end = tmp as usize;
+        } else {
+            end = self.text_info.highlight_info.start;
+            start = tmp as usize;
+        }
+
+        (start, end)
+    }
 }
 
 pub fn highlight_text(text: String, app: &App) -> Line {
-    let start;
-    let end;
-    let tmp = app.text_info.highlight_info.start as i32 + app.text_info.highlight_info.distance;
-    if tmp as usize > app.text_info.highlight_info.start {
-        start = app.text_info.highlight_info.start;
-        end = tmp as usize;
-    } else {
-        end = app.text_info.highlight_info.start;
-        start = tmp as usize;
-    }
+    let (start, end) = app.get_highlight_start_and_end();
 
     let pre_highlight = &text[0..start];
     let pre_highlight_span = Span::raw(pre_highlight.to_owned());

--- a/src/display/theme.rs
+++ b/src/display/theme.rs
@@ -46,6 +46,9 @@ fn magenta_default() -> Color {
 fn red_default() -> Color {
     Color::Red
 }
+fn black_default() -> Color {
+    Color::Black
+}
 
 /// Struct holds all the color configurations for `checklist`
 /// that the user can change
@@ -89,6 +92,10 @@ pub struct ThemeColors {
     pub pop_up_outline: Color,
     #[serde(default = "blue_default")]
     pub state_box_outline_during_tags_edit: Color,
+    #[serde(default = "cyan_default")]
+    pub highlight_color_bg: Color,
+    #[serde(default = "black_default")]
+    pub highlight_color_fg: Color,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -224,7 +231,7 @@ pub fn create_empty_theme_toml() -> Result<()> {
 
     let theme_elements = Theme::FIELD_NAMES_AS_ARRAY;
     for element in theme_elements {
-        file.write(format!("[{}]\n", element).as_bytes())
+        file.write(format!("[{element}]\n").as_bytes())
             .context("Failed when writing theme elements to newly created theme.toml")?;
     }
     println!("Created a default theme.toml file");
@@ -243,7 +250,7 @@ impl Theme {
                 // This minimizes the chance of data being lost if an error
                 // happens mid-write
                 let toml_file = String::from("theme.toml");
-                let tmp_file = format!("{}.tmp", toml_file);
+                let tmp_file = format!("{toml_file}.tmp");
 
                 let toml_file_path = conf_local_dir.join(&toml_file);
                 let tmp_file_path = conf_local_dir.join(&tmp_file);
@@ -259,10 +266,10 @@ impl Theme {
 
                 // Rename .tmp file to old file
                 rename(&tmp_file_path, &toml_file_path)
-                    .with_context(|| { format!("Failed to update config file with rename:\ntmp_file: {:?}\nconfig_file:{:?}", tmp_file, toml_file)})?;
+                    .with_context(|| { format!("Failed to update config file with rename:\ntmp_file: {tmp_file:?}\nconfig_file:{toml_file:?}")})?;
             }
             Err(e) => {
-                println!("Failed getting the configuration location: {:?}", e);
+                println!("Failed getting the configuration location: {e:?}");
                 panic!()
             }
         }
@@ -280,7 +287,7 @@ pub fn get_toml_file() -> Result<PathBuf> {
             Ok(toml_file_path)
         }
         Err(e) => {
-            println!("Failed getting the theme toml at: {:?}", e);
+            println!("Failed getting the theme toml at: {e:?}");
             panic!()
         }
     }
@@ -290,7 +297,7 @@ pub fn get_toml_file() -> Result<PathBuf> {
 pub fn read_theme() -> Result<Theme> {
     let toml_file_path = get_toml_file()?;
     let toml_file = std::fs::File::open(&toml_file_path)
-        .with_context(|| format!("Failed to open {:?}", toml_file_path))?;
+        .with_context(|| format!("Failed to open {toml_file_path:?}"))?;
     let mut reader = BufReader::new(toml_file);
 
     let mut buf = String::new();
@@ -306,8 +313,8 @@ pub fn read_theme() -> Result<Theme> {
         // by Theme, which can then fill in defaults
         // as needed
         if !buf.contains(element) {
-            buf.push_str(&format!("\n[{}]", element));
-            println!("Added new theme element [{}] into the theme.toml", element);
+            buf.push_str(&format!("\n[{element}]"));
+            println!("Added new theme element [{element}] into the theme.toml");
         }
     }
 
@@ -358,6 +365,6 @@ mod tests {
         "#,
         )
         .unwrap();
-        println!("{:?}", theme);
+        println!("{theme:?}");
     }
 }

--- a/src/display/tui.rs
+++ b/src/display/tui.rs
@@ -20,6 +20,7 @@ use crate::display::render::{
     render_name_popup, render_stage_popup, render_state, render_status_bar, render_status_popup,
     render_tags_popup, render_task_info, render_tasks, render_urgency_popup,
 };
+use crate::display::text::TextInfo;
 use crate::display::theme::Theme;
 
 use self::common::{init_terminal, install_hooks, restore_terminal};
@@ -105,6 +106,8 @@ pub struct App {
     pub tasklist: TaskList,
     // Scrollbar related
     pub scroll_info: ScrollInfo,
+    // Text related
+    pub text_info: TextInfo,
     // Sizing related
     list_box_sizing: u16,
     // Popup related
@@ -115,7 +118,6 @@ pub struct App {
     pub add_popup: bool,
     pub add_stage: Stage,
     pub inputs: Inputs,
-    pub character_index: usize,
     // Update related
     pub update_popup: bool,
     pub update_stage: Stage,
@@ -162,13 +164,13 @@ impl App {
             cursor_info: CursorInfo::default(),
             tasklist,
             scroll_info: ScrollInfo::default(),
+            text_info: TextInfo::new(),
             list_box_sizing: 30,
             delete_popup: false,
             entry_mode: EntryMode::Add,
             add_popup: false,
             add_stage: Stage::default(),
             inputs: Inputs::default(),
-            character_index: 0,
             update_popup: false,
             update_stage: Stage::default(),
             highlight_tags: false,
@@ -373,7 +375,7 @@ impl App {
                 KeyCode::Char('a') => {
                     self.add_popup = !self.add_popup;
                     self.inputs = Inputs::default();
-                    self.character_index = 0;
+                    self.text_info.character_index = 0;
                     self.add_stage = Stage::Name;
                     self.entry_mode = EntryMode::Add;
                     self.highlight_tags = false;

--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -534,7 +534,7 @@ impl Renderer {
                     self.stdout.queue(cursor::MoveTo(start_x, start_y))?;
                     current_line_usage = width as i32;
                 }
-                self.stdout.queue(Print(format!("{} ", word)))?;
+                self.stdout.queue(Print(format!("{word} ")))?;
                 current_line_usage -= word.chars().count() as i32 + 1;
             }
         }


### PR DESCRIPTION
Added a variety of improvements to how text is handled for some of the inputs

# Highlighting text

Can now highlight text via:

- `Ctrl + a` to highlight all text
- `Shift + <=` or `Shift + =>` to highlight a single character at a time

Once highlighted, the text can either be deleted or a new character entered which replaces the highlighted text.

# Movement

Added the ability to quickly move to the beginning or end of the text with `Ctrl + <=` or `Ctrl + =>`

# Theme

Highlight background and foreground color can be changed in the theme via the `highlight_color_bg` and `highlight_color_fg` values respectively